### PR TITLE
Rename GSG::Gitc to App::Gitc

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -42,13 +42,13 @@ inc/Module/Install/Metadata.pm
 inc/Module/Install/Scripts.pm
 inc/Module/Install/Win32.pm
 inc/Module/Install/WriteAll.pm
-lib/GSG/Gitc.pm
-lib/GSG/Gitc/Config.pm
-lib/GSG/Gitc/Its/Eventum.pm
-lib/GSG/Gitc/Its/Jira.pm
-lib/GSG/Gitc/Test.pm
-lib/GSG/Gitc/Util.pm
-lib/GSG/Reversible.pm
+lib/App/Gitc.pm
+lib/App/Gitc/Config.pm
+lib/App/Gitc/Its/Eventum.pm
+lib/App/Gitc/Its/Jira.pm
+lib/App/Gitc/Reversible.pm
+lib/App/Gitc/Test.pm
+lib/App/Gitc/Util.pm
 LICENSE
 Makefile.PL
 MANIFEST			This list of files

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,7 +1,7 @@
 use inc::Module::Install;
 
-name 'GSG-Gitc';
-all_from 'lib/GSG/Gitc.pm';
+name 'App-Gitc';
+all_from 'lib/App/Gitc.pm';
 
 # modules present in the core Perl installation
 requires 'Carp';

--- a/gitc-archive-tags
+++ b/gitc-archive-tags
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     git
     git_config
     git_dir
@@ -40,7 +40,7 @@ exit if not $tags_fh;  # refs to process
 
 # normally we don't access dbh directly, but we need a transaction,
 # so we need the database handle itself.
-my $dbh = GSG::Gitc::Util::dbh();
+my $dbh = App::Gitc::Util::dbh();
 $dbh->begin_work;
 
 # which changesets are old?

--- a/gitc-branch
+++ b/gitc-branch
@@ -20,7 +20,7 @@ use strict;
 
 # Hide warnings from ITS/Jira
 
-use GSG::Gitc::Util qw( its_for_changeset );
+use App::Gitc::Util qw( its_for_changeset );
 BEGIN {
     $SIG{'__WARN__'} = sub { }
 }

--- a/gitc-branch-point
+++ b/gitc-branch-point
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     branch_point
 );
 

--- a/gitc-cancel
+++ b/gitc-cancel
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     changeset_merged_to
     confirm
     current_branch
@@ -27,7 +27,7 @@ use GSG::Gitc::Util qw(
     meta_data_rm_all
     remote_branch_exists
 );
-use GSG::Reversible;
+use App::Gitc::Reversible;
 use Getopt::Long;
 
 our $changeset = current_branch();

--- a/gitc-changesets-in
+++ b/gitc-changesets-in
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     changesets_in
 );
 

--- a/gitc-current-branch
+++ b/gitc-current-branch
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     current_branch
 );
 

--- a/gitc-diff
+++ b/gitc-diff
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw( branch_point );
+use App::Gitc::Util qw( branch_point );
 
 my $merge_base = branch_point();
 exec "git diff --no-prefix @ARGV $merge_base HEAD";

--- a/gitc-diff-versions
+++ b/gitc-diff-versions
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     current_branch
     current_branch_version
     is_valid_ref

--- a/gitc-diffsites
+++ b/gitc-diffsites
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw( environment_preceding );
+use App::Gitc::Util qw( environment_preceding );
 
 my $target = shift or die "You must specify a target environment\n";
 my $source = environment_preceding($target)

--- a/gitc-edit
+++ b/gitc-edit
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     git
     git_fetch_and_clean_up
     guarantee_a_clean_working_directory
@@ -29,7 +29,7 @@ use GSG::Gitc::Util qw(
     remote_branch_exists
     project_name
 );
-use GSG::Reversible;
+use App::Gitc::Reversible;
 
 my $changeset = shift or die "You must specify a changeset name\n";
 git_fetch_and_clean_up();

--- a/gitc-fail
+++ b/gitc-fail
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     current_branch
     git
     guarantee_a_clean_working_directory
@@ -31,7 +31,7 @@ use GSG::Gitc::Util qw(
     project_name
     sendmail
 );
-use GSG::Reversible;
+use App::Gitc::Reversible;
 use Getopt::Long;
 
 my $with_changes = 0;

--- a/gitc-group
+++ b/gitc-group
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     changeset_group
     changeset_merged_to
     history

--- a/gitc-history
+++ b/gitc-history
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     branch_basis
     branch_point
     changeset_merged_to

--- a/gitc-import-tags
+++ b/gitc-import-tags
@@ -19,7 +19,7 @@ use warnings;
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use File::Temp qw( tempfile );
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     archived_tags
     git_dir
     open_packed_refs

--- a/gitc-list
+++ b/gitc-list
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw( project_name unmerged_changesets );
+use App::Gitc::Util qw( project_name unmerged_changesets );
 use Getopt::Long;
 
 my $format = 'basic';
@@ -39,7 +39,7 @@ die "You must specify a project on the command line or with you pwd\n"
 my $unmerged = unmerged_changesets($project_name);
 
 # display the results
-my $class = 'GSG::Gitc::ListFormat::' . ucfirst( lc $format );
+my $class = 'App::Gitc::ListFormat::' . ucfirst( lc $format );
 my $formatter = $class->new;
 $formatter->print_header;
 for my $changeset ( sort keys %$unmerged ) {
@@ -51,7 +51,7 @@ $formatter->print_footer;
 #######################################################################
 # various list format implementations
 
-package GSG::Gitc::ListFormat::Base;
+package App::Gitc::ListFormat::Base;
 use strict;
 use warnings;
 sub new {
@@ -61,11 +61,11 @@ sub print_header {}
 sub print_row {}
 sub print_footer {}
 
-package GSG::Gitc::ListFormat::Basic;
+package App::Gitc::ListFormat::Basic;
 use strict;
 use warnings;
-use base qw( GSG::Gitc::ListFormat::Base );
-use GSG::Gitc::Util qw( history_owner history_reviewer history_status );
+use base qw( App::Gitc::ListFormat::Base );
+use App::Gitc::Util qw( history_owner history_reviewer history_status );
 
 sub print_header {
     print "owner    id              status    timestamp             user     reviewer\n";
@@ -87,11 +87,11 @@ sub print_row {
     ;
 }
 
-package GSG::Gitc::ListFormat::Summary;
+package App::Gitc::ListFormat::Summary;
 use strict;
 use warnings;
-use base qw( GSG::Gitc::ListFormat::Base );
-use GSG::Gitc::Util qw( history_status history_reviewer );
+use base qw( App::Gitc::ListFormat::Base );
+use App::Gitc::Util qw( history_status history_reviewer );
 
 sub print_header {
     my ($self) = @_;
@@ -137,11 +137,11 @@ sub print_footer {
     }
 }
 
-package GSG::Gitc::ListFormat::Yaml;
+package App::Gitc::ListFormat::Yaml;
 use strict;
 use warnings;
-use base qw( GSG::Gitc::ListFormat::Base );
-use GSG::Gitc::Util qw(
+use base qw( App::Gitc::ListFormat::Base );
+use App::Gitc::Util qw(
     history_owner history_status history_reviewer
     its_for_changeset
 );
@@ -179,10 +179,10 @@ sub print_row {
     print YAML::Syck::Dump($data);
 }
 
-package GSG::Gitc::ListFormat::Dump;
+package App::Gitc::ListFormat::Dump;
 use strict;
 use warnings;
-use base qw( GSG::Gitc::ListFormat::Base );
+use base qw( App::Gitc::ListFormat::Base );
 
 sub print_row {
     my ($self, $changeset, $history) = @_;

--- a/gitc-log
+++ b/gitc-log
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     branch_point
     current_branch
     full_changeset_name

--- a/gitc-open
+++ b/gitc-open
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     changeset_group
     changeset_merged_to
     confirm
@@ -38,7 +38,7 @@ use GSG::Gitc::Util qw(
     project_config
     project_name
 );
-use GSG::Reversible;
+use App::Gitc::Reversible;
 use Getopt::Long;
 use List::MoreUtils qw( none );
 

--- a/gitc-pass
+++ b/gitc-pass
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     confirm
     current_branch
     full_changeset_name
@@ -38,7 +38,7 @@ use GSG::Gitc::Util qw(
     sort_changesets_by_name
     unpromoted
 );
-use GSG::Reversible;
+use App::Gitc::Reversible;
 use Getopt::Long;
 
 my $skip_email = 0;

--- a/gitc-project-name
+++ b/gitc-project-name
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     project_name
 );
 

--- a/gitc-promote
+++ b/gitc-promote
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     confirm
     current_branch
     environment_preceding
@@ -39,7 +39,7 @@ use GSG::Gitc::Util qw(
     sort_changesets_by_name
     unpromoted
 );
-use GSG::Reversible;
+use App::Gitc::Reversible;
 use POSIX qw( strftime );
 use Getopt::Long qw( :config pass_through );
 

--- a/gitc-promoted
+++ b/gitc-promoted
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     changesets_promoted_between
     git
     project_name

--- a/gitc-quickfix
+++ b/gitc-quickfix
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw( highest_quickfix_number project_name );
+use App::Gitc::Util qw( highest_quickfix_number project_name );
 
 my $n = highest_quickfix_number( project_name() ) || 0;
 $n++;

--- a/gitc-rebase
+++ b/gitc-rebase
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     branch_point
     full_changeset_name
     git

--- a/gitc-review
+++ b/gitc-review
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     git
     git_fetch_and_clean_up
     history
@@ -29,7 +29,7 @@ use GSG::Gitc::Util qw(
     history_status
     history_reviewer
 );
-use GSG::Reversible;
+use App::Gitc::Reversible;
 
 # make sure we can really review this changeset
 our $changeset = shift or die "You must specify a changeset\n";

--- a/gitc-setup
+++ b/gitc-setup
@@ -18,8 +18,8 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw( git );
-use GSG::Gitc::Config;
+use App::Gitc::Util qw( git );
+use App::Gitc::Config;
 
 my $project = shift;
 my $alias   = shift || '';

--- a/gitc-show
+++ b/gitc-show
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     archived_tags
     branch_point
     current_branch

--- a/gitc-submit
+++ b/gitc-submit
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     branch_basis
     branch_point
     confirm
@@ -37,7 +37,7 @@ use GSG::Gitc::Util qw(
     project_config
     project_name
 );
-use GSG::Reversible;
+use App::Gitc::Reversible;
 use Getopt::Long;
 use List::MoreUtils qw( any );
 
@@ -368,7 +368,7 @@ sub update_email_headers {
     return;
 }
 
-# this might be worth factoring out to GSG::Gitc::Util at some point
+# this might be worth factoring out to App::Gitc::Util at some point
 sub author_email {
     my $git_config = git_config();
     my $name       = $git_config->{user}{name};

--- a/gitc-sync
+++ b/gitc-sync
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     git
     confirm current_branch
     guarantee_a_clean_working_directory

--- a/gitc-touch
+++ b/gitc-touch
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw( meta_data_add parse_changeset_spec );
+use App::Gitc::Util qw( meta_data_add parse_changeset_spec );
 
 my $changeset_spec = shift;
 my ( $project_name, $changeset ) = parse_changeset_spec($changeset_spec);

--- a/gitc-unpromoted
+++ b/gitc-unpromoted
@@ -18,7 +18,7 @@ use warnings;
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     environment_preceding
     git
     is_auto_fetch

--- a/lib/App/Gitc.pm
+++ b/lib/App/Gitc.pm
@@ -1,12 +1,12 @@
 use strict;
 use warnings;
-package GSG::Gitc;
+package App::Gitc;
 
 our $VERSION = '0.57';
 
 =head1 See
 
-L<GSG::Gitc::Util>
+L<App::Gitc::Util>
 
 =head1 AUTHOR
 

--- a/lib/App/Gitc/Config.pm
+++ b/lib/App/Gitc/Config.pm
@@ -1,4 +1,4 @@
-package GSG::Gitc::Config;
+package App::Gitc::Config;
 use strict;
 use warnings;
 

--- a/lib/App/Gitc/Its/Eventum.pm
+++ b/lib/App/Gitc/Its/Eventum.pm
@@ -1,8 +1,8 @@
-package GSG::Gitc::Its::Eventum;
+package App::Gitc::Its::Eventum;
 
 =head1 NAME
 
-GSG::Gitc::Its::Eventum;
+App::Gitc::Its::Eventum;
 
 =head1 Synopsis
 
@@ -16,7 +16,7 @@ Support for Eventum ITS (Issue Tracking System)
 
 use POSIX qw( strftime );
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     project_config
     command_name
     current_branch

--- a/lib/App/Gitc/Its/Jira.pm
+++ b/lib/App/Gitc/Its/Jira.pm
@@ -1,8 +1,8 @@
-package GSG::Gitc::Its::Jira;
+package App::Gitc::Its::Jira;
 
 =head1 NAME
 
-GSG::Gitc::Its::Jira;
+App::Gitc::Its::Jira;
 
 =head1 Synopsis
 
@@ -27,7 +27,7 @@ use Try::Tiny;
 use List::MoreUtils qw( any );
 use YAML;
 
-use GSG::Gitc::Util qw(
+use App::Gitc::Util qw(
     project_config
     command_name
     current_branch

--- a/lib/App/Gitc/Reversible.pm
+++ b/lib/App/Gitc/Reversible.pm
@@ -1,4 +1,4 @@
-package GSG::Reversible;
+package App::Gitc::Reversible;
 use strict;
 use warnings;
 use base 'Exporter';
@@ -13,11 +13,11 @@ BEGIN {
 
 =head1 NAME
 
-GSG::Reversible - simple reversible computation
+App::Gitc::Reversible - simple reversible computation
 
 =head1 Synopsis
 
-    use GSG::Reversible;
+    use App::Gitc::Reversible;
     reversibly {
         # do something with a side effect
         open my $fh, '>', '/tmp/file' or die;

--- a/lib/App/Gitc/Test.pm
+++ b/lib/App/Gitc/Test.pm
@@ -1,4 +1,4 @@
-package GSG::Gitc::Test;
+package App::Gitc::Test;
 use strict;
 use warnings;
 
@@ -18,7 +18,7 @@ use warnings;
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use Test::More '';
-use GSG::Gitc::Util qw( branch_point unpromoted );
+use App::Gitc::Util qw( branch_point unpromoted );
 use Exporter 'import';
 
 BEGIN {

--- a/lib/App/Gitc/Util.pm
+++ b/lib/App/Gitc/Util.pm
@@ -1,4 +1,4 @@
-package GSG::Gitc::Util;
+package App::Gitc::Util;
 use strict;
 use warnings;
 
@@ -133,7 +133,7 @@ object... but this fits the bill.
 sub _package_its {
     my $its_type = shift;
 
-    return 'GSG::Gitc::Its::'.ucfirst $its_type; 
+    return 'App::Gitc::Its::'.ucfirst $its_type; 
 }
 sub its {
     my $its = shift || project_config()->{'default_its'};
@@ -423,8 +423,8 @@ Returns a hashref with configuration details about this project.
 =cut
 
 sub project_config {
-    require GSG::Gitc::Config;
-    my $projects = $GSG::Gitc::Config::config{projects};
+    require App::Gitc::Config;
+    my $projects = $App::Gitc::Config::config{projects};
     my $project_config = $projects->{ project_name() };
     return $project_config if defined $project_config;
     return $projects->{_default};

--- a/t/reversible.t
+++ b/t/reversible.t
@@ -17,7 +17,7 @@ use warnings;
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use Test::More tests => 18;
-use GSG::Reversible;
+use App::Gitc::Reversible;
 
 # set up what we'll need for the tests
 my @english;

--- a/t/sort_changeset_ids_by_name.t
+++ b/t/sort_changeset_ids_by_name.t
@@ -19,7 +19,7 @@ use warnings;
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use Test::More;
-use GSG::Gitc::Util qw( sort_changesets_by_name );
+use App::Gitc::Util qw( sort_changesets_by_name );
 
 my @tests = (
     [


### PR DESCRIPTION
Use App::Gitc as the namespace. Using App::GitGot as the precedent. It's a
reasonable namespace and an easy conversion.

This should resolve issue #2.
